### PR TITLE
Handle ESPN season year parameter and expose API year option

### DIFF
--- a/ff_draft_assistant/populate_espn.py
+++ b/ff_draft_assistant/populate_espn.py
@@ -28,7 +28,7 @@ def populate_from_espn(league_id: str, year: int = 2024, free_agent_limit: int =
     try:
         if espn_s2 and swid:
             league = League(
-                league_id=league_id, year=season, espn_s2=espn_s2, swid=swid
+                league_id=league_id, year=year, espn_s2=espn_s2, swid=swid
             )
         else:
             league = League(league_id=league_id, year=year)


### PR DESCRIPTION
## Summary
- Fix ESPN population to use the provided `year` when creating the `League`
- Allow `/api/populate-espn` endpoint to accept a `year` parameter with validation and default to current year

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8f0518c483269b89290c5ef43777