### PR TITLE
feat: add season parameter to get_drafts_by_user

### DIFF
--- a/ff_draft_assistant/README.md
+++ b/ff_draft_assistant/README.md
@@ -56,6 +56,14 @@ python app.py
 3. **Access the Web Interface**:
 Open your browser to `http://localhost:4000`
 
+4. **Fetch Sleeper Drafts for a User** (Optional):
+```python
+from ff_draft_assistant.sleeper_api import SleeperAPI
+
+drafts = SleeperAPI.get_drafts_by_user("your_username")  # defaults to current season
+drafts_2023 = SleeperAPI.get_drafts_by_user("your_username", season=2023)
+```
+
 ## Project Structure
 
 ```

--- a/ff_draft_assistant/sleeper_api.py
+++ b/ff_draft_assistant/sleeper_api.py
@@ -1,5 +1,8 @@
-import requests
+import logging
+from datetime import datetime
 from typing import List, Dict, Any
+
+import requests
 
 class SleeperAPI:
     BASE_URL = "https://api.sleeper.app/v1"
@@ -12,11 +15,31 @@ class SleeperAPI:
         return response.json()
 
     @staticmethod
-    def get_drafts_by_user(username: str) -> List[Dict[str, Any]]:
-        url = f"{SleeperAPI.BASE_URL}/user/{username}/drafts/nfl/2025"
-        response = requests.get(url)
-        response.raise_for_status()
-        return response.json()
+    def get_drafts_by_user(username: str, season: int | None = None) -> List[Dict[str, Any]]:
+        """Retrieve drafts for a user for a given season.
+
+        Args:
+            username: Sleeper username.
+            season: Four-digit year of the season. Defaults to the current year.
+
+        Returns:
+            A list of draft dictionaries. Returns an empty list if the response is invalid
+            or the request fails.
+        """
+
+        season = season or datetime.now().year
+        url = f"{SleeperAPI.BASE_URL}/user/{username}/drafts/nfl/{season}"
+
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            data = response.json()
+            if not isinstance(data, list):
+                raise ValueError("Invalid response format: expected a list of drafts")
+            return data
+        except (requests.RequestException, ValueError) as exc:
+            logging.error("Failed to fetch drafts for user %s: %s", username, exc)
+            return []
 
     @staticmethod
     def get_draft_picks(draft_id: str) -> List[Dict[str, Any]]:
@@ -27,5 +50,6 @@ class SleeperAPI:
 
 # Example usage:
 # players = SleeperAPI.get_players()
-# drafts = SleeperAPI.get_drafts_by_user('your_username')
+# drafts = SleeperAPI.get_drafts_by_user('your_username')  # defaults to current season
+# drafts_2023 = SleeperAPI.get_drafts_by_user('your_username', season=2023)
 # picks = SleeperAPI.get_draft_picks('draft_id')


### PR DESCRIPTION
## Summary
- allow specifying season when retrieving Sleeper drafts by user with current year default
- document Sleeper draft retrieval with optional season parameter
- add error handling for unexpected API responses

## Testing
- `python -m py_compile ff_draft_assistant/sleeper_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab8f28b7348326877b6b6386986036