### PR TITLE
Use relative imports within package

### DIFF
--- a/ff_draft_assistant/app.py
+++ b/ff_draft_assistant/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template, request, jsonify
-from mongo_utils import get_all_players, search_players
-from populate_espn import populate_from_espn
+from .mongo_utils import get_all_players, search_players
+from .populate_espn import populate_from_espn
 from dotenv import load_dotenv
 import logging
 import os

--- a/ff_draft_assistant/draft_assistant.py
+++ b/ff_draft_assistant/draft_assistant.py
@@ -1,6 +1,6 @@
-from ff_draft_assistant.pdf_parser import PDFPlayerSheet
-from ff_draft_assistant.sleeper_api import SleeperAPI
-from ff_draft_assistant.espn_http_api import ESPNAPI
+from .pdf_parser import PDFPlayerSheet
+from .sleeper_api import SleeperAPI
+from .espn_http_api import ESPNAPI
 
 class DraftAssistant:
     def __init__(self, pdf_path: str, json_path: str):

--- a/ff_draft_assistant/main.py
+++ b/ff_draft_assistant/main.py
@@ -1,10 +1,10 @@
 
 import os
 
-from pdf_parser import PDFPlayerSheet
-from openai_parser import parse_table_with_openai
+from .pdf_parser import PDFPlayerSheet
+from .openai_parser import parse_table_with_openai
 import pdfplumber
-from mongo_utils import insert_players, search_players, get_all_players
+from .mongo_utils import insert_players, search_players, get_all_players
 
 def extract_pdf_text(pdf_path):
     text = ""

--- a/ff_draft_assistant/populate_espn.py
+++ b/ff_draft_assistant/populate_espn.py
@@ -3,7 +3,7 @@ from typing import Dict, Any
 from datetime import datetime
 from dotenv import load_dotenv
 from espn_api.football import League
-from mongo_utils import insert_players
+from .mongo_utils import insert_players
 
 load_dotenv()
 

--- a/ff_draft_assistant/run_assistant.py
+++ b/ff_draft_assistant/run_assistant.py
@@ -1,4 +1,4 @@
-from ff_draft_assistant.draft_assistant import DraftAssistant
+from .draft_assistant import DraftAssistant
 import os
 
 def main():


### PR DESCRIPTION
## Summary
- Switch package modules to use relative imports so internal references work when executed as a package

## Testing
- `python -m ff_draft_assistant.run_assistant` *(fails: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f36e0ec83268f365bbf43bcfffe