### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ff_draft_assistant/requirements.txt
+      - name: Run tests
+        run: |
+          pytest --cov=ff_draft_assistant --cov-report=term --cov-fail-under=30

--- a/ff_draft_assistant/requirements.txt
+++ b/ff_draft_assistant/requirements.txt
@@ -2,6 +2,8 @@ pdfplumber
 requests
 openai
 python-dotenv
-"pymongo[srv]"
+pymongo[srv]
 flask
 espn-api
+pytest
+pytest-cov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for package imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_mongo_utils.py
+++ b/tests/test_mongo_utils.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import types
+import pytest
+from importlib import reload
+
+# Provide minimal stubs if real packages are unavailable
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+
+class DummyMongoClient:
+    def __init__(self, uri):
+        pass
+    def __getitem__(self, name):
+        return self
+
+sys.modules.setdefault("pymongo", types.SimpleNamespace(MongoClient=DummyMongoClient))
+
+os.environ["MONGO_URI"] = "mongodb://localhost:27017"
+from ff_draft_assistant import mongo_utils as mongo_utils_module
+mongo_utils = reload(mongo_utils_module)
+
+class DummyCollection:
+    def __init__(self):
+        self.data = []
+
+    def delete_many(self, _):
+        self.data = []
+
+    def insert_many(self, docs):
+        self.data.extend(docs)
+
+    def find(self, query, projection=None):
+        def match(doc):
+            for k, v in query.items():
+                if doc.get(k) != v:
+                    return False
+            return True
+        return [d for d in self.data if match(d)]
+
+@pytest.fixture
+def patched_mongo(monkeypatch):
+    dummy = DummyCollection()
+    monkeypatch.setattr(mongo_utils, "collection", dummy)
+    return mongo_utils, dummy
+
+def test_insert_search_get_all(patched_mongo):
+    mu, dummy = patched_mongo
+    players = [
+        {"name": "A", "position": "RB"},
+        {"name": "B", "position": "QB"},
+    ]
+    mu.insert_players(players)
+    assert dummy.data == players
+    assert mu.search_players({"position": "RB"}) == [{"name": "A", "position": "RB"}]
+    assert mu.get_all_players() == players

--- a/tests/test_openai_parser.py
+++ b/tests/test_openai_parser.py
@@ -1,0 +1,25 @@
+import types
+import sys
+
+# Provide a minimal openai stub if the real package is unavailable
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=None))
+
+from ff_draft_assistant import openai_parser
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+class DummyClient:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(
+                create=lambda **kwargs: DummyResponse('[{"player":"A","position":"QB"}]')
+            )
+        )
+
+def test_parse_table_with_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(openai_parser, "openai", types.SimpleNamespace(OpenAI=lambda api_key: DummyClient()))
+    result = openai_parser.parse_table_with_openai("text", ["player", "position"])
+    assert result == [{"player": "A", "position": "QB"}]

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,0 +1,45 @@
+import types
+import sys
+
+# Provide a minimal pdfplumber stub if the real package is unavailable
+sys.modules.setdefault("pdfplumber", types.SimpleNamespace(open=lambda path: None))
+
+from ff_draft_assistant import pdf_parser
+
+class DummyPage:
+    def __init__(self, text):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+class DummyPDF:
+    def __init__(self, pages):
+        self.pages = pages
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+def test_parse_pdf_and_mark(monkeypatch):
+    sample = "1. Christian McCaffrey RB SF\n2. Justin Jefferson WR MIN"
+    dummy_pdf = DummyPDF([DummyPage(sample)])
+    monkeypatch.setattr(pdf_parser, "pdfplumber", types.SimpleNamespace(open=lambda _: dummy_pdf))
+    sheet = pdf_parser.PDFPlayerSheet("dummy.pdf")
+    sheet.parse_pdf()
+    assert len(sheet.players) == 2
+    sheet.mark_drafted("Christian McCaffrey")
+    available = [p.name for p in sheet.get_available_players()]
+    assert "Justin Jefferson" in available
+    assert "Christian McCaffrey" not in available
+
+def test_save_and_load(tmp_path):
+    sheet = pdf_parser.PDFPlayerSheet("dummy.pdf")
+    sheet.players = [pdf_parser.Player("Test Player", "QB", "NYJ", 1)]
+    file = tmp_path / "players.json"
+    sheet.save(file)
+    new_sheet = pdf_parser.PDFPlayerSheet("dummy.pdf")
+    new_sheet.load(file)
+    assert new_sheet.players[0].name == "Test Player"


### PR DESCRIPTION
## Summary
- add tests for pdf, OpenAI, and Mongo utilities
- add GitHub Actions workflow running pytest with coverage enforcement
- include test dependencies

## Testing
- `pytest`
- `pytest --cov=ff_draft_assistant --cov-report=term --cov-fail-under=30` *(fails: pytest: error: unrecognized arguments: --cov=ff_draft_assistant --cov-report=term --cov-fail-under=30)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f42baac8326bb42f6c7a253fdd1